### PR TITLE
Make `githooks run` require the `--name` argument

### DIFF
--- a/poetry_githooks/__init__.py
+++ b/poetry_githooks/__init__.py
@@ -30,6 +30,7 @@ def setup():
 @cli.command(context_settings=dict(ignore_unknown_options=True))
 @click.option(
     "--name",
+    required=True,
     type=click.Choice(settings.VALID_HOOKS_NAME),
     help="Name of the hook to run",
 )


### PR DESCRIPTION
Previously, not passing a hook name would result in trying to execute a hook named `None`:
```
githooks run
No hooks called None found. Add a [tool.githooks] section to your pyproject.toml with the desired hook
```
Now, this fails earlier with a more intuitive message:
```
 githooks run
Usage: githooks run [OPTIONS] [ARGS]...
Try 'githooks run --help' for help.

Error: Missing option '--name'.  Choose from:
	applypatch-msg,
	pre-applypatch,
	post-applypatch,
...
```