### PR TITLE
Add option to explicitly define root git directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This repository is made to work with [poetry](https://python-poetry.org/). Assum
 ```
 poetry add -D poetry-githooks
 ```
-
+If your root git directory is not the project directory, define `POETRY_GITHOOKS_GIT_ROOT` environment variable
+and set it to the directory that `.git` resides in.<br>
+(For example, if the path to `.git` is `/somepath/.git`, then you should set `POETRY_GITHOOKS_GIT_ROOT=/somepath/`)
 ## Install
 
 Create a `tool.githooks` section in your `pyproject.toml` file and define your git hooks, for example

--- a/poetry_githooks/hooks.py
+++ b/poetry_githooks/hooks.py
@@ -69,6 +69,7 @@ def write(hook: str):
             hook_file.write(
                 f"""#!/bin/bash
 {settings.SIGNATURE}
+cd {settings.BASE_DIR}
 poetry run githooks run --name {hook} $@"""
             )
 

--- a/poetry_githooks/settings.py
+++ b/poetry_githooks/settings.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 BASE_DIR = os.path.realpath(".")
-GIT_DIR = os.path.join(BASE_DIR, ".git")
+GIT_DIR = os.path.join(os.getenv("POETRY_GITHOOKS_GIT_ROOT", BASE_DIR), ".git")
 GITHOOKS_DIR = os.path.join(GIT_DIR, "hooks")
 CONFIG_FILE = os.path.join(BASE_DIR, "pyproject.toml")
 


### PR DESCRIPTION
It is a PR for issue #8.
I needed to add `cd {settings.BASE_DIR}` before running the hook, since git changes hooks' working directory to the root of the working tree - if it is equal to `BASE_DIR`, then it's ok, but if not, then we must explicitly change the directory.